### PR TITLE
 remove cls=self.decoder from response.json() call in parse() method

### DIFF
--- a/berserk/formats.py
+++ b/berserk/formats.py
@@ -73,7 +73,7 @@ class JsonHandler(FormatHandler):
         :return: response data
         :rtype: JSON
         """
-        return response.json(cls=self.decoder)
+        return response.json()
 
     def parse_stream(self, response):
         """Yield the parsed data from a stream response.


### PR DESCRIPTION
Resolves https://github.com/rhgrant10/berserk/issues/17 same PR as https://github.com/rhgrant10/berserk/pull/32